### PR TITLE
Fix CIDs

### DIFF
--- a/src/dns.h
+++ b/src/dns.h
@@ -56,7 +56,7 @@ class DNSMessage
                 int  ancount;
                 int  nscount;
                 int  arcount;
-                Header()
+                Header() : z(0)
                 {
                     id=0;
                     qr=0;

--- a/src/packet_handler.h
+++ b/src/packet_handler.h
@@ -83,6 +83,12 @@ class Payload
 class IP_header
 {
 public:
+    IP_header() : s(0), us(0), ethertype(0), src_port(0), dst_port(0), proto(0), ip_ttl(0), id(0), length(0), fragments(0), ident(0), offset(0)
+    {
+        memset(&src_ip, 0, sizeof(src_ip));
+        memset(&dst_ip, 0, sizeof(dst_ip));
+    }
+
     void reset();
     int decode(unsigned char *data, int ether_type,int id);
     unsigned int       s;
@@ -180,7 +186,7 @@ struct Packet_column
 class Packet_handler
 {
 public:
-    Packet_handler()
+    Packet_handler() : table_name(0)
     {
     }
     virtual ~Packet_handler()

--- a/src/packetq.cpp
+++ b/src/packetq.cpp
@@ -231,7 +231,7 @@ int main (int argc, char * argv [])
     g_app->set_limit(limit);
     if (port>0)
     {
-	start_server( port, daemon, webroot, pcaproot, max_conn );
+	start_server( port, daemon, pcaproot, webroot, max_conn );
     }
 
     if (optind >= argc) {

--- a/src/reader.h
+++ b/src/reader.h
@@ -36,7 +36,7 @@ namespace se
     class Reader
     {
     public:
-        Reader(std::vector<std::string> filenames, int max_packets)
+        Reader(std::vector<std::string> filenames, int max_packets) : packets_read(0)
         {
             this->filenames = filenames;
             this->currently_reading = filenames.end();

--- a/src/segzip.h
+++ b/src/segzip.h
@@ -46,7 +46,7 @@ class Buffer
 class Zip
 {
     public:
-        Zip()
+        Zip() : m_stream()
         {
             m_init    = true;
             m_error   = false;

--- a/src/sql.cpp
+++ b/src/sql.cpp
@@ -184,6 +184,10 @@ class Per_sort
 public:
     struct Tlink
     {
+        Tlink() : m_eq(0)
+        {
+        }
+
         Tlink *get_eq() {return m_eq;}
         void reset()
         {
@@ -1450,7 +1454,7 @@ class Parser
                         continue;
                     }
                     else
-                        throw Error("Got unary '%s' but could not parse follwing expression",op->get_token() );
+                        throw Error("Got unary '%s' but could not parse following expression",op->get_token() );
 
                     operand_stack.push(op);
                     success = true;
@@ -2750,7 +2754,7 @@ Table *DB::create_table(const char *i_name)
 
     return t;
 }
-Column::Column(const char *name,Coltype::Type type, int id, bool hidden): m_name(name), m_type(type), m_def(Column::m_coldefs[type]), m_id(id)
+Column::Column(const char *name,Coltype::Type type, int id, bool hidden): m_name(name), m_type(type), m_def(Column::m_coldefs[type]), m_id(id), m_offset(0)
 {
     m_hidden = hidden;
 }

--- a/src/sql.h
+++ b/src/sql.h
@@ -338,6 +338,10 @@ template <typename T>
 class Accessor
 {
 public:
+    Accessor() : m_offset(0)
+    {
+    }
+
     T &value(Row *row);
 
     int m_offset;
@@ -361,7 +365,7 @@ public:
 class Table
 {
     public:
-    Table(const char *name = 0, const char *query = 0)
+    Table(const char *name = 0, const char *query = 0) : m_rsize(0), m_dsize(0)
     {
         m_row_allocator = 0;
         m_name = name?name:"result";
@@ -1503,7 +1507,7 @@ class Bin_op_like : public OP
 	bool	m_compiled;
 	int	m_err;
     public:
-	Bin_op_like(const OP &op): OP(op){
+	Bin_op_like(const OP &op): OP(op), m_re() {
 	    m_err = 0;
 	    m_compiled = false;
 	}

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -34,8 +34,10 @@ class Stream_id
 {
     public:
         /// constructor
-        Stream_id()
+        Stream_id() : m_src_port(0), m_dst_port(0)
         {
+            memset(&m_src_ip, 0, sizeof(m_src_ip));
+            memset(&m_dst_ip, 0, sizeof(m_dst_ip));
         }
         /// constructor taking source and destination adresses
         Stream_id(  in6addr_t &src_ip,


### PR DESCRIPTION
- 1436279: Initialize all `se::Stream_id` members
- 1436277: Initialize all `se::Reader` members
- 1436276: Initialize all `se::DNSMessage::Header` members
- 1436275: Removed unused `m_max` from `se::httpd::SocketPool`
- 1436274: Initialize all `se::httpd::Socket` members
- 1436272: Initialize all `se::Zip` members
- 1436271, 1436267: Initialize all `se::Accessor` members
- 1436270, 1436265: Initialize all `se::IP_header` members
- 1436269: Initialize all `se::Column` members
- 1436268: Initialize all `se::https::Http_socket` members
- 1436266: Initialize all `se::Bin_op_like` members
- 1436264: Initialize all `se::Table` members
- 1436263: Initialize all `se::Packet_handler` members
- 1436262: Initialize all `se::Per_sort::Tlink` members
- 1436261: Correct order of arguments passed to HTTP server
- 1436260: Fix leak, socket descriptor can be zero
- Fix typo in exception