### PR TITLE
Add basic EDNS option code and ECS address extraction support

### DIFF
--- a/FIELDS.md
+++ b/FIELDS.md
@@ -15,13 +15,16 @@ the dns table, presented as JSON identifiers.
       { "name": "src_addr","type": "text" },
       { "name": "dst_addr","type": "text" },
       { "name": "protocol","type": "int" },
+      { "name": "ip_ttl","type": "int" },
+      { "name": "fragments","type": "int" },
       { "name": "qname","type": "text" },
       { "name": "aname","type": "text" },
       { "name": "msg_id","type": "int" },
+      { "name": "msg_size","type": "int" },
       { "name": "opcode","type": "int" },
       { "name": "rcode","type": "int" },
       { "name": "extended_rcode","type": "int" },
-      { "name": "version","type": "int" },
+      { "name": "edns_version","type": "int" },
       { "name": "z","type": "int" },
       { "name": "udp_size","type": "int" },
       { "name": "qd_count","type": "int" },
@@ -41,7 +44,12 @@ the dns table, presented as JSON identifiers.
       { "name": "ad","type": "bool" },
       { "name": "do","type": "bool" },
       { "name": "edns0","type": "bool" },
-      { "name": "qr","type": "bool" }
+      { "name": "qr","type": "bool" },
+      { "name": "edns0_esc","type": "bool" },
+      { "name": "edns0_esc_family","type": "int" },
+      { "name": "edns0_esc_source","type": "int" },
+      { "name": "edns0_esc_scope","type": "int" },
+      { "name": "edns0_esc_address","type": "text" }
   }
 ]
 ```

--- a/FIELDS.md
+++ b/FIELDS.md
@@ -45,11 +45,11 @@ the dns table, presented as JSON identifiers.
       { "name": "do","type": "bool" },
       { "name": "edns0","type": "bool" },
       { "name": "qr","type": "bool" },
-      { "name": "edns0_esc","type": "bool" },
-      { "name": "edns0_esc_family","type": "int" },
-      { "name": "edns0_esc_source","type": "int" },
-      { "name": "edns0_esc_scope","type": "int" },
-      { "name": "edns0_esc_address","type": "text" }
+      { "name": "edns0_ecs","type": "bool" },
+      { "name": "edns0_ecs_family","type": "int" },
+      { "name": "edns0_ecs_source","type": "int" },
+      { "name": "edns0_ecs_scope","type": "int" },
+      { "name": "edns0_ecs_address","type": "text" }
   }
 ]
 ```

--- a/src/dns.cpp
+++ b/src/dns.cpp
@@ -82,11 +82,11 @@ void Parse_dns::add_packet_columns()
     add_packet_column("edns0", "", Coltype::_bool, COLUMN_EDNS0);
     add_packet_column("qr", "", Coltype::_bool, COLUMN_QR);
 
-    add_packet_column("edns0_esc", "", Coltype::_bool, COLUMN_EDNS0_ECS);
-    add_packet_column("edns0_esc_family", "", Coltype::_int, COLUMN_EDNS0_ECS_FAMILY);
-    add_packet_column("edns0_esc_source", "", Coltype::_int, COLUMN_EDNS0_ECS_SOURCE);
-    add_packet_column("edns0_esc_scope", "", Coltype::_int, COLUMN_EDNS0_ECS_SCOPE);
-    add_packet_column("edns0_esc_address", "", Coltype::_text, COLUMN_EDNS0_ECS_ADDRESS);
+    add_packet_column("edns0_ecs", "", Coltype::_bool, COLUMN_EDNS0_ECS);
+    add_packet_column("edns0_ecs_family", "", Coltype::_int, COLUMN_EDNS0_ECS_FAMILY);
+    add_packet_column("edns0_ecs_source", "", Coltype::_int, COLUMN_EDNS0_ECS_SOURCE);
+    add_packet_column("edns0_ecs_scope", "", Coltype::_int, COLUMN_EDNS0_ECS_SCOPE);
+    add_packet_column("edns0_ecs_address", "", Coltype::_text, COLUMN_EDNS0_ECS_ADDRESS);
 }
 
 void Parse_dns::add_lookup_tables()
@@ -218,11 +218,11 @@ void Parse_dns::on_table_created(Table* table, const std::vector<int>& columns)
     acc_qname = table->get_accessor<text_column>("qname");
     acc_aname = table->get_accessor<text_column>("aname");
 
-    acc_edns0_ecs = table->get_accessor<bool_column>("edns0_esc");
-    acc_edns0_ecs_family = table->get_accessor<int_column>("edns0_esc_family");
-    acc_edns0_ecs_source = table->get_accessor<int_column>("edns0_esc_source");
-    acc_edns0_ecs_scope = table->get_accessor<int_column>("edns0_esc_scope");
-    acc_edns0_ecs_address = table->get_accessor<text_column>("edns0_esc_address");
+    acc_edns0_ecs = table->get_accessor<bool_column>("edns0_ecs");
+    acc_edns0_ecs_family = table->get_accessor<int_column>("edns0_ecs_family");
+    acc_edns0_ecs_source = table->get_accessor<int_column>("edns0_ecs_source");
+    acc_edns0_ecs_scope = table->get_accessor<int_column>("edns0_ecs_scope");
+    acc_edns0_ecs_address = table->get_accessor<text_column>("edns0_ecs_address");
 }
 
 Packet::ParseResult Parse_dns::parse(Packet& packet, const std::vector<int>& columns, Row& destination_row, bool sample)

--- a/src/dns.cpp
+++ b/src/dns.cpp
@@ -63,6 +63,8 @@ void Parse_dns::add_packet_columns()
     add_packet_column("edns_version", "", Coltype::_int, COLUMN_EDNS_VERSION);
     add_packet_column("z", "", Coltype::_int, COLUMN_Z);
     add_packet_column("udp_size", "", Coltype::_int, COLUMN_UDP_SIZE);
+    add_packet_column("edns_opcode", "", Coltype::_int, COLUMN_EDNS_OPCODE);
+    add_packet_column("ecs_addr", "", Coltype::_text, COLUMN_ECS_ADDR);
     add_packet_column("qd_count", "", Coltype::_int, COLUMN_QD_COUNT);
     add_packet_column("an_count", "", Coltype::_int, COLUMN_AN_COUNT);
     add_packet_column("ns_count", "", Coltype::_int, COLUMN_NS_COUNT);
@@ -189,6 +191,7 @@ void Parse_dns::on_table_created(Table* table, const std::vector<int>& columns)
     acc_edns_version = table->get_accessor<int_column>("edns_version");
     acc_z = table->get_accessor<int_column>("z");
     acc_udp_size = table->get_accessor<int_column>("udp_size");
+    acc_edns_opcode = table->get_accessor<int_column>("edns_opcode");
     acc_qd_count = table->get_accessor<int_column>("qd_count");
     acc_an_count = table->get_accessor<int_column>("an_count");
     acc_ns_count = table->get_accessor<int_column>("ns_count");
@@ -211,6 +214,7 @@ void Parse_dns::on_table_created(Table* table, const std::vector<int>& columns)
 
     acc_qname = table->get_accessor<text_column>("qname");
     acc_aname = table->get_accessor<text_column>("aname");
+    acc_ecs_addr = table->get_accessor<text_column>("ecs_addr");
 }
 
 Packet::ParseResult Parse_dns::parse(Packet& packet, const std::vector<int>& columns, Row& destination_row, bool sample)
@@ -343,6 +347,14 @@ Packet::ParseResult Parse_dns::parse(Packet& packet, const std::vector<int>& col
 
         case COLUMN_UDP_SIZE:
             acc_udp_size.value(r) = message.m_edns0 ? message.m_udp_size : 0;
+            break;
+
+        case COLUMN_EDNS_OPCODE:
+            acc_edns_opcode.value(r) = message.m_edns_opcode ? message.m_edns_opcode : 0;
+            break;
+
+        case COLUMN_ECS_ADDR:
+            acc_ecs_addr.value(r) = message.m_ecs ? RefCountString::construct(message.m_ecs_addr) : RefCountString::construct("");
             break;
 
         case COLUMN_ANAME:

--- a/src/dns.cpp
+++ b/src/dns.cpp
@@ -63,8 +63,6 @@ void Parse_dns::add_packet_columns()
     add_packet_column("edns_version", "", Coltype::_int, COLUMN_EDNS_VERSION);
     add_packet_column("z", "", Coltype::_int, COLUMN_Z);
     add_packet_column("udp_size", "", Coltype::_int, COLUMN_UDP_SIZE);
-    add_packet_column("edns_opcode", "", Coltype::_int, COLUMN_EDNS_OPCODE);
-    add_packet_column("ecs_addr", "", Coltype::_text, COLUMN_ECS_ADDR);
     add_packet_column("qd_count", "", Coltype::_int, COLUMN_QD_COUNT);
     add_packet_column("an_count", "", Coltype::_int, COLUMN_AN_COUNT);
     add_packet_column("ns_count", "", Coltype::_int, COLUMN_NS_COUNT);
@@ -83,6 +81,12 @@ void Parse_dns::add_packet_columns()
     add_packet_column("do", "", Coltype::_bool, COLUMN_DO);
     add_packet_column("edns0", "", Coltype::_bool, COLUMN_EDNS0);
     add_packet_column("qr", "", Coltype::_bool, COLUMN_QR);
+
+    add_packet_column("edns0_esc", "", Coltype::_bool, COLUMN_EDNS0_ECS);
+    add_packet_column("edns0_esc_family", "", Coltype::_int, COLUMN_EDNS0_ECS_FAMILY);
+    add_packet_column("edns0_esc_source", "", Coltype::_int, COLUMN_EDNS0_ECS_SOURCE);
+    add_packet_column("edns0_esc_scope", "", Coltype::_int, COLUMN_EDNS0_ECS_SCOPE);
+    add_packet_column("edns0_esc_address", "", Coltype::_text, COLUMN_EDNS0_ECS_ADDRESS);
 }
 
 void Parse_dns::add_lookup_tables()
@@ -191,7 +195,6 @@ void Parse_dns::on_table_created(Table* table, const std::vector<int>& columns)
     acc_edns_version = table->get_accessor<int_column>("edns_version");
     acc_z = table->get_accessor<int_column>("z");
     acc_udp_size = table->get_accessor<int_column>("udp_size");
-    acc_edns_opcode = table->get_accessor<int_column>("edns_opcode");
     acc_qd_count = table->get_accessor<int_column>("qd_count");
     acc_an_count = table->get_accessor<int_column>("an_count");
     acc_ns_count = table->get_accessor<int_column>("ns_count");
@@ -214,7 +217,12 @@ void Parse_dns::on_table_created(Table* table, const std::vector<int>& columns)
 
     acc_qname = table->get_accessor<text_column>("qname");
     acc_aname = table->get_accessor<text_column>("aname");
-    acc_ecs_addr = table->get_accessor<text_column>("ecs_addr");
+
+    acc_edns0_ecs = table->get_accessor<bool_column>("edns0_esc");
+    acc_edns0_ecs_family = table->get_accessor<int_column>("edns0_esc_family");
+    acc_edns0_ecs_source = table->get_accessor<int_column>("edns0_esc_source");
+    acc_edns0_ecs_scope = table->get_accessor<int_column>("edns0_esc_scope");
+    acc_edns0_ecs_address = table->get_accessor<text_column>("edns0_esc_address");
 }
 
 Packet::ParseResult Parse_dns::parse(Packet& packet, const std::vector<int>& columns, Row& destination_row, bool sample)
@@ -349,14 +357,6 @@ Packet::ParseResult Parse_dns::parse(Packet& packet, const std::vector<int>& col
             acc_udp_size.value(r) = message.m_edns0 ? message.m_udp_size : 0;
             break;
 
-        case COLUMN_EDNS_OPCODE:
-            acc_edns_opcode.value(r) = message.m_edns_opcode ? message.m_edns_opcode : 0;
-            break;
-
-        case COLUMN_ECS_ADDR:
-            acc_ecs_addr.value(r) = message.m_ecs ? RefCountString::construct(message.m_ecs_addr) : RefCountString::construct("");
-            break;
-
         case COLUMN_ANAME:
             acc_aname.value(r) = header.ancount ? RefCountString::construct(message.m_answer[0].name) : RefCountString::construct("");
             break;
@@ -371,6 +371,31 @@ Packet::ParseResult Parse_dns::parse(Packet& packet, const std::vector<int>& col
 
         case COLUMN_ATTL:
             acc_attl.value(r) = header.ancount ? message.m_answer[0].ttl : 0;
+            break;
+
+        case COLUMN_EDNS0_ECS:
+            acc_edns0_ecs.value(r) = message.m_edns0_ecs ? 1 : 0;
+            break;
+
+        case COLUMN_EDNS0_ECS_FAMILY:
+            acc_edns0_ecs_family.value(r) = message.m_edns0_ecs_family;
+            break;
+
+        case COLUMN_EDNS0_ECS_SOURCE:
+            acc_edns0_ecs_source.value(r) = message.m_edns0_ecs_source;
+            break;
+
+        case COLUMN_EDNS0_ECS_SCOPE:
+            acc_edns0_ecs_scope.value(r) = message.m_edns0_ecs_scope;
+            break;
+
+        case COLUMN_EDNS0_ECS_ADDRESS:
+            if (message.m_edns0_ecs_addr_set && message.m_edns0_ecs_family == 1)
+                acc_edns0_ecs_address.value(r) = v4_addr2str(message.m_edns0_ecs_addr);
+            else if (message.m_edns0_ecs_addr_set && message.m_edns0_ecs_family == 2)
+                acc_edns0_ecs_address.value(r) = v6_addr2str(message.m_edns0_ecs_addr);
+            else
+                acc_edns0_ecs_address.value(r) = RefCountString::construct("");
             break;
         }
     }

--- a/src/dns.h
+++ b/src/dns.h
@@ -140,8 +140,10 @@ public:
         {
             offs = m.parse_dname(name, sizeof(name), offs);
             type = m.get_ushort(offs);
-            if (type == 41)
+            if (type == 41) {
                 m.m_opt_rr = this;
+                m.m_new_opt_rr = true;
+            }
             offs += 2;
             rr_class = m.get_ushort(offs);
             offs += 2;
@@ -165,6 +167,7 @@ public:
     RR m_authority[2];
     RR m_additional[2];
     RR* m_opt_rr;
+    bool m_new_opt_rr;
     int m_error;
     bool m_edns0;
     bool m_do;
@@ -183,6 +186,7 @@ public:
         : m_ip_header(head)
     {
         m_opt_rr = 0;
+        m_new_opt_rr = false;
         m_error = 0;
         m_data = data;
         m_length = len;
@@ -236,7 +240,8 @@ public:
         out[p++] = 0;
         return offs;
     }
-    void parse_opt_rr() {
+    void parse_opt_rr()
+    {
         if (m_opt_rr) {
             if (!m_edns0) {
                 m_edns0 = true;
@@ -247,7 +252,7 @@ public:
                 m_z = ttl & 0x7fff;
                 m_udp_size = m_opt_rr->rr_class;
             }
-            if ((m_opt_rr->ttl >> 16) & 0xff == 0) {
+            if (((m_opt_rr->ttl >> 16) & 0xff) == 0 && m_opt_rr->rdlength > 0) {
                 // Parse this OPT RR that is EDNS0
                 int rdlen = m_opt_rr->rdlength,
                     offs = m_opt_rr->doffs,
@@ -270,18 +275,36 @@ public:
                         m_edns0_ecs_family = get_ushort(offs);
                         m_edns0_ecs_source = get_ubyte(offs + 2);
                         m_edns0_ecs_scope = get_ubyte(offs + 3);
-                        if (m_edns0_ecs_family == 1 && oplen == 8) {
-                            m_edns0_ecs_addr.__in6_u.__u6_addr32[3] = get_uint32(offs + 4);
-                            m_edns0_ecs_addr_set = true;
-                        }
-                        else if (m_edns0_ecs_family == 2 && oplen == 20) {
-                            m_edns0_ecs_addr.__in6_u.__u6_addr32[3] = get_uint32(offs + 4);
-                            m_edns0_ecs_addr.__in6_u.__u6_addr32[2] = get_uint32(offs + 8);
-                            m_edns0_ecs_addr.__in6_u.__u6_addr32[1] = get_uint32(offs + 12);
-                            m_edns0_ecs_addr.__in6_u.__u6_addr32[0] = get_uint32(offs + 16);
-                            m_edns0_ecs_addr_set = true;
+
+                        int addrlen = (m_edns0_ecs_source / 8) + (m_edns0_ecs_source % 8 ? 1 : 0);
+                        int fill = 0;
+
+                        if (addrlen <= (oplen - 4)) {
+                            switch (m_edns0_ecs_family) {
+                            case 1:
+                                fill = 4;
+                                m_edns0_ecs_addr_set = true;
+                                break;
+                            case 2:
+                                fill = 16;
+                                m_edns0_ecs_addr_set = true;
+                                break;
+                            }
+
+                            int a, b;
+                            for (a = 0, b = 15; fill && b > -1; fill--, b--) {
+                                if (a < addrlen) {
+                                    m_edns0_ecs_addr.__in6_u.__u6_addr8[b] = get_ubyte(offs + 4 + a);
+                                    a++;
+                                } else {
+                                    m_edns0_ecs_addr.__in6_u.__u6_addr8[b] = 0;
+                                }
+                            }
                         }
                     }
+
+                    rdlen -= oplen;
+                    offs += oplen;
                 }
             }
         }
@@ -330,7 +353,10 @@ public:
                 m_error = offs;
                 return;
             }
-            parse_opt_rr();
+            if (m_new_opt_rr) {
+                parse_opt_rr();
+                m_new_opt_rr = false;
+            }
         }
         if (offs > m_length)
             m_error = offs;

--- a/src/packetq.cpp
+++ b/src/packetq.cpp
@@ -81,11 +81,11 @@ static void usage(char* argv0, bool longversion)
                     "      do\n"
                     "      edns0\n"
                     "      qr\n"
-                    "      edns0_esc\n"
-                    "      edns0_esc_family\n"
-                    "      edns0_esc_source\n"
-                    "      edns0_esc_scope\n"
-                    "      edns0_esc_address\n"
+                    "      edns0_ecs\n"
+                    "      edns0_ecs_family\n"
+                    "      edns0_ecs_source\n"
+                    "      edns0_ecs_scope\n"
+                    "      edns0_ecs_address\n"
     );
 }
 

--- a/src/packetq.cpp
+++ b/src/packetq.cpp
@@ -85,8 +85,7 @@ static void usage(char* argv0, bool longversion)
                     "      edns0_ecs_family\n"
                     "      edns0_ecs_source\n"
                     "      edns0_ecs_scope\n"
-                    "      edns0_ecs_address\n"
-    );
+                    "      edns0_ecs_address\n");
 }
 
 #ifdef WIN32

--- a/src/packetq.cpp
+++ b/src/packetq.cpp
@@ -80,9 +80,13 @@ static void usage(char* argv0, bool longversion)
                     "      ad\n"
                     "      do\n"
                     "      edns0\n"
-                    "      edns_opcode\n"
-                    "      ecs_addr\n"
-                    "      qr\n");
+                    "      qr\n"
+                    "      edns0_esc\n"
+                    "      edns0_esc_family\n"
+                    "      edns0_esc_source\n"
+                    "      edns0_esc_scope\n"
+                    "      edns0_esc_address\n"
+    );
 }
 
 #ifdef WIN32

--- a/src/packetq.cpp
+++ b/src/packetq.cpp
@@ -80,6 +80,8 @@ static void usage(char* argv0, bool longversion)
                     "      ad\n"
                     "      do\n"
                     "      edns0\n"
+                    "      edns_opcode\n"
+                    "      ecs_addr\n"
                     "      qr\n");
 }
 


### PR DESCRIPTION
There are several issues with this code:
 * EDNS option code of the first EDNS extension is parsed only
 * ECS address field is only extracted if it is the first EDNS extension
 * ECS address field is only extracted for IPv4 addresses
   and scope is not supported. /24 is assumed. For /32 it omits more
   details. For /16 it will likely calculate wrong
