### PR TITLE
OpenBSD clang warnings

### DIFF
--- a/src/output.h
+++ b/src/output.h
@@ -72,7 +72,7 @@ public:
         if (m_len > sizeof(m_buffer) / 2)
             print();
         char c;
-        while (c = *p++) {
+        while ((c = *p++)) {
             if (c == '\\') {
                 m_buffer[m_len++] = '\\';
                 c                 = '\\';
@@ -101,7 +101,7 @@ public:
         if (c == 0)
             return;
         p--;
-        while (c = *p++) {
+        while ((c = *p++)) {
             if (c == '>') {
                 m_buffer[m_len++] = '&';
                 add_string("gt");
@@ -137,7 +137,7 @@ public:
     {
         check();
         char c;
-        while (c = *p++) {
+        while ((c = *p++)) {
             m_buffer[m_len++] = c;
         }
     }
@@ -246,21 +246,21 @@ public:
         if (i < 256) {
             add_string_q(m_diglut[i & 255]);
         } else {
-            char d[5];
+            unsigned char d[64];
 
-            char* cd = d;
-            while (i > 0) {
+            unsigned char* cd = d;
+            while (i > 0 && cd < (&d[0] + sizeof(d))) {
                 unsigned int n = i;
                 i              = i / 100;
                 n              = n - (i * 100);
                 *cd++          = n;
             }
             if (cd != d) {
-                char t = *--cd;
+                unsigned char t = *--cd;
                 add_string_q(m_diglut[t]);
             }
             while (cd != d) {
-                char t = *--cd;
+                unsigned char t = *--cd;
                 if (t >= 10)
                     add_string_q(m_diglut[t]);
                 else {
@@ -297,7 +297,7 @@ private:
     inline void add_string_q(const char* p)
     {
         char c;
-        while (c = *p++) {
+        while ((c = *p++)) {
             m_buffer[m_len++] = c;
         }
     }
@@ -368,7 +368,7 @@ public:
     inline void add_string_q(const char* p)
     {
         char c;
-        while (c = *p++) {
+        while ((c = *p++)) {
             m_buffer[m_len++] = c;
         }
     }

--- a/src/pcap.cpp
+++ b/src/pcap.cpp
@@ -49,11 +49,11 @@ bool Pcap_file::get_header()
         return false;
     }
     // check for 0 timezone offset and accuracy
-    if (!get_int32() == 0) {
+    if (!(get_int32() == 0)) {
         printf("timezone offset != 0");
         return false;
     }
-    if (!get_int32() == 0) {
+    if (!(get_int32() == 0)) {
         printf("timezone offset != 0");
         return false;
     }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -238,7 +238,7 @@ namespace httpd {
                 unsigned char ptr[4096];
                 int           len;
 
-                while (len = m_write.read(ptr, sizeof(ptr))) {
+                while ((len = m_write.read(ptr, sizeof(ptr)))) {
                     int res = write(m_socket, ptr, len);
 #if EAGAIN != EWOULDBLOCK
                     if (res == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
@@ -995,7 +995,7 @@ namespace httpd {
                     pfd.fd      = m_child_fd;
                     pfd.events  = POLLIN;
                     pfd.revents = 0;
-                    if (1 == poll(&pfd, 1, 0) && (pfd.revents & POLLIN != 0)) {
+                    if (1 == poll(&pfd, 1, 0) && (pfd.revents & POLLIN) != 0) {
                         if ((res = read(m_child_fd, buffer, (int)sizeof(buffer))) > 0) {
                             done = false;
                             m_child_read += res;

--- a/src/sql.cpp
+++ b/src/sql.cpp
@@ -880,11 +880,13 @@ void Table::csv(bool format)
             continue;
 
         printf("%s", csv_qoute_string(m_cols[i]->m_name).c_str());
-        if (i < cols - 1)
-            if (format)
+        if (i < cols - 1) {
+            if (format) {
                 printf("%s,", &tmp[csv_qoute_string(m_cols[i]->m_name).length() + max - col_len[i] + 1]);
-            else
+            } else {
                 printf(",");
+            }
+        }
     }
     printf("\n");
     for (std::list<Row*>::iterator it = m_rows.begin(); it != m_rows.end(); it++) {
@@ -920,11 +922,13 @@ void Table::csv(bool format)
             }
 
             fputs(out.c_str(), stdout);
-            if (i < cols - 1)
-                if (format)
+            if (i < cols - 1) {
+                if (format) {
                     printf("%s,", &tmp[out.length() + max - col_len[i] + 1]);
-                else
+                } else {
                     printf(",");
+                }
+            }
         }
 
         printf("\n");
@@ -1103,7 +1107,7 @@ public:
             }
         }
         it = save;
-        if (res = get_expr(it, 0)) {
+        if ((res = get_expr(it, 0))) {
             save = it;
 
             if (is(it, Token::_label, "as")) {
@@ -1130,7 +1134,7 @@ public:
         bool success = true;
         while (again) {
             OP* op;
-            if (op = get_result_column(it)) {
+            if ((op = get_result_column(it))) {
                 q.m_select.push_back(op);
             } else {
                 success = false;
@@ -1152,7 +1156,7 @@ public:
     bool get_ordering_terms(Ordering_terms& ordering, std::list<Token>::iterator& it)
     {
         OP* op;
-        while (op = get_expr(it, 0)) {
+        while ((op = get_expr(it, 0))) {
             bool asc = true;
             if (it->get_type() == Token::_label) {
                 if (cmpi(it->get_token(), "asc")) {
@@ -1250,7 +1254,7 @@ public:
             return true;
         it++;
         OP* res = 0;
-        if (res = get_expr(it, 0)) {
+        if ((res = get_expr(it, 0))) {
             q.m_having = res;
             return true;
         }
@@ -1265,7 +1269,7 @@ public:
             return true;
         it++;
         OP* res = 0;
-        if (res = get_expr(it, 0)) {
+        if ((res = get_expr(it, 0))) {
             q.m_where = res;
             return true;
         }
@@ -1380,7 +1384,7 @@ public:
             if (expect_expr && is(it, Token::_paren, "(")) {
                 it++;
                 OP* op = 0;
-                if (op = get_expr(it, rec + 1)) {
+                if ((op = get_expr(it, rec + 1))) {
                     if (is(it, Token::_paren, ")")) {
                         it++;
                         operand_stack.push(op);
@@ -1756,7 +1760,6 @@ public:
         _e,
         _sign,
         _exp,
-        _exit
     };
 
     Num_state num_state;
@@ -2499,6 +2502,6 @@ void Trim_func::evaluate(Row** rows, Variant& v)
 
 DB g_db;
 
-Coldef Column::m_coldefs[Coltype::_max];
+Coldef Column::m_coldefs[COLTYPE_MAX];
 
 } // namespace packetq

--- a/src/sql.h
+++ b/src/sql.h
@@ -307,7 +307,7 @@ class Column {
 public:
     static const bool HIDDEN = true;
 
-    static Coldef m_coldefs[Coltype::_max];
+    static Coldef m_coldefs[COLTYPE_MAX];
     Column(const char* name, Coltype::Type type, int id, bool hidden);
     // called at startup by DB
     static void init_defs()

--- a/src/variant.h
+++ b/src/variant.h
@@ -37,13 +37,13 @@ inline std::size_t hash_bytes(const char* bytes, int len)
 }
 
 // must be defined in this order - see the "if" statement
+#define COLTYPE_MAX 4
 namespace Coltype {
     enum Type {
-        _bool,
-        _int,
-        _float,
-        _text,
-        _max
+        _bool  = 0,
+        _int   = 1,
+        _float = 2,
+        _text  = 3,
     };
 };
 


### PR DESCRIPTION
- Fix OpenBSD clang++ compiler warnings
- `Output::add_int()`: Fix potential memory overwrite