### PR TITLE
Memory align, TCP assemble

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,9 +25,7 @@ SUBDIRS = test
 AM_CXXFLAGS = -I$(srcdir) \
   -I$(srcdir)/Murmur \
   -I$(top_srcdir) \
-  $(libmaxminddb_CFLAGS) \
-  -std=c++0x \
-  -Wall -Wno-parentheses -Wno-switch -Wno-sign-compare -Wno-char-subscripts
+  $(libmaxminddb_CFLAGS)
 
 bin_PROGRAMS = packetq
 


### PR DESCRIPTION
- Remove some compiler flags
- `Allocator`:
  - Fix memory alignment
  - Rename private sub-class to `_Buffer` to not mix it up with other `Buffer` class
- `Row`: replace `ROW_DUMMY_SIZE` with size of a pointer
- TCP Stream:
  - Fix `Stream_id` class, was leaking memory left and right
  - Add cleanup code in `Stream`
  - Make sure we got data for DNS length